### PR TITLE
Don't depend on deprecated `Mix.Util` functions

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -54,7 +54,7 @@ defmodule ProperCase do
   def camel_case(key) when is_binary(key) do
     first_char = key |> first
     key
-    |> Mix.Utils.camelize
+    |> Macro.camelize
     |> replace(upcase(first_char), downcase(first_char), global: false)
   end
 
@@ -64,14 +64,14 @@ defmodule ProperCase do
   def snake_case(val) when is_atom(val) do
     val
     |> Atom.to_string
-    |> Mix.Utils.underscore 
+    |> Macro.underscore
   end
 
   @doc """
   Converts a string to `snake_case`
   """
   def snake_case(val) do
-    val |> Mix.Utils.underscore
+    val |> Macro.underscore
   end
 
 


### PR DESCRIPTION
`Mix.Util.camelize` and `Mix.Util.underscore` have been deprecated in favor of the same functions in the `Macro` module, which were added in Elixir 1.2:
https://github.com/elixir-lang/elixir/commit/b3595595a71e29683fb5a8c9facf9f9fe1a13c00

I noticed this when trying to use this library in production, when I got an error:

```
function Mix.Utils.underscore/1 is undefined (module Mix.Utils is not available)
```

This is because `mix` is not declared explicitly as a dependency to `proper_case`, so it's not available on production.

Similar issues:
- https://github.com/trenpixster/addict/issues/73
- https://github.com/trenpixster/addict/pull/75

Thanks for the library!
