### PR TITLE
Preserve leading underscores for camel_case_key

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -35,12 +35,10 @@ defmodule ProperCase do
     |> Enum.map(&to_snake_case/1)
   end
 
-  def to_snake_case(other_types), do: other_types 
+  def to_snake_case(other_types), do: other_types
 
-  
-  
   @doc """
-  Converts an atom to a `camelCase` string 
+  Converts an atom to a `camelCase` string
   """
   def camel_case(key) when is_atom(key) do
     key
@@ -51,6 +49,10 @@ defmodule ProperCase do
   @doc """
   Converts a string to `camelCase`
   """
+  def camel_case("_" <> rest) do
+    "_#{camel_case(rest)}"
+  end
+
   def camel_case(key) when is_binary(key) do
     first_char = key |> first
     key

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -1,6 +1,6 @@
 defmodule ProperCaseTest do
   use ExUnit.Case
-  
+
   test ".to_camel_case converts a maps key to `camelCase`" do
     incoming = %{ "user" => %{ "first_name" => "Han", "last_name" => "Solo",
         "allies_in_combat" => [
@@ -18,15 +18,20 @@ defmodule ProperCaseTest do
           %{"name" => "Luke", "weaponOfChoice" => "lightsaber"},
           %{"name" => "Chewie", "weaponOfChoice" => "bowcaster"},
           %{"name" => "Leia", "weaponOfChoice" => "blaster"}
-        ] 
+        ]
       }
-    } 
+    }
 
     assert ProperCase.to_camel_case(incoming) === expected
   end
 
   test ".camel_case_key camel cases a string" do
     assert ProperCase.camel_case("chewie_were_home") === "chewieWereHome"
+  end
+
+  test ".camel_case_key ignores leading underscore" do
+    assert ProperCase.camel_case("_boba_fett_where") === "_bobaFettWhere"
+    assert ProperCase.camel_case("__boba_fett_where") === "__bobaFettWhere"
   end
 
   test ".camel_case_key converts an atom to a string and camel cases it" do
@@ -52,9 +57,9 @@ defmodule ProperCaseTest do
           %{"name" => "Luke", "weaponOfChoice" => "lightsaber"},
           %{"name" => "Chewie", "weaponOfChoice" => "bowcaster"},
           %{"name" => "Leia", "weaponOfChoice" => "blaster"}
-        ] 
+        ]
       }
-    } 
+    }
     assert ProperCase.to_snake_case(incoming_params) === expected_params
   end
 


### PR DESCRIPTION
Elixir's Macro.camelize will ditch any leading underscores and upcase
the first letter.

e.g.

iex(4)> Macro.camelize("_foo")
=> "Foo"