### PR TITLE
Add custom encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ Plug it into your `router.ex` connection pipeline like so:
   end
 ```
 
-### Transform data before encoding for JSON with Phoenix
+### CamelCase before encoding json in Phoenix
+
+Set phoenix's json encoder in `config/config.exs`
+
+```elixir
+  :phoenix, :format_encoders, json: ProperCase.JSONEncoder.CamelCase
+```
+
+### Custom data transform before encoding with Phoenix
 
 Define a custom JSON encoder that runs a transform before encoding to json.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ Plug it into your `router.ex` connection pipeline like so:
   end
 ```
 
+### Transform data before encoding for JSON with Phoenix
+
+Define a custom JSON encoder that runs a transform before encoding to json.
+
+```elixir
+def MyApp.CustomJSONEncoder do
+  use ProperCase.JSONEncoder, transform: &ProperCase.to_camel_case/1
+end
+```
+
+config.exs
+
+```elixir
+  :phoenix, :format_encoders, json: MyApp.CustomJSONEncoder
+```
 
 
 ## Installation

--- a/lib/json_encoder.ex
+++ b/lib/json_encoder.ex
@@ -1,0 +1,32 @@
+defmodule ProperCase.JSONEncoder do
+  @moduledoc """
+    module that exposes a version of `encode_to_iodata!/1` that transforms data
+    before encoding to json. This is designed to work with phoenix.
+
+    Options:
+    transform - artity 1 function that is executed before passing the result to json_encoder.encode_to_iodata!
+    json_encoder - JSON encoder that implements encode_to_iodata!. Default: Poison
+
+    usage:
+      def MyApp.CustomJSONEncoder do
+        use ProperCase.JSONEncoder, transform: &ProperCase.to_camel_case/1
+      end
+
+      config.exs
+
+      :phoenix, :format_encoders, json: MyApp.CustomJSONEncoder
+
+  """
+
+  defmacro __using__(options) do
+    json_encoder = Keyword.get(options, :json_encoder, Poison)
+
+    quote do
+      def encode_to_iodata!(data) do
+        data
+        |> unquote(options[:transform]).()
+        |> unquote(json_encoder).encode_to_iodata!
+      end
+    end
+  end
+end

--- a/lib/json_encoder/camel_case.ex
+++ b/lib/json_encoder/camel_case.ex
@@ -1,0 +1,3 @@
+defmodule ProperCase.JSONEncoder.CamelCase do
+  use ProperCase.JSONEncoder, transform: &ProperCase.to_camel_case/1
+end

--- a/lib/plug/snake_case_params.ex
+++ b/lib/plug/snake_case_params.ex
@@ -11,13 +11,11 @@ defmodule ProperCase.Plug.SnakeCaseParams do
     end
 
   Enjoy :)
-   """ 
-   
+   """
+
   def init(opts), do: opts
 
   def call(%{params: params} = conn, _opts) do
     %{conn | params: ProperCase.to_snake_case(params)}
   end
-
-  
 end

--- a/mix.exs
+++ b/mix.exs
@@ -29,9 +29,9 @@ defmodule ProperCase.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.14.3"},
+      {:ex_doc, "~> 0.14.3", only: :dev},
       {:plug, "~> 1.2.2", only: [:test]},
-      {:poison, ">= 1.3.0", optional: true},
+      {:poison, ">= 1.3.0", only: [:test]},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,12 +29,14 @@ defmodule ProperCase.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.14.3"}
+      {:ex_doc, "~> 0.14.3"},
+      {:plug, "~> 1.2.2", only: [:test]},
+      {:poison, ">= 1.3.0", optional: true},
     ]
   end
 
   defp package do
-    [ 
+    [
       files: ["lib", "mix.exs", "README*", "LICENSE"],
       maintainers: ["Johnny Ji"],
       licenses: ["Apache 2.0"],
@@ -43,6 +45,6 @@ defmodule ProperCase.Mixfile do
         "Docs" => "https://github.com/johnnyji/proper_case"
       }
     ]
-  end 
+  end
 
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
 %{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}

--- a/test/json_encoder/camel_case_test.exs
+++ b/test/json_encoder/camel_case_test.exs
@@ -1,0 +1,33 @@
+defmodule ProperCase.JSONEncoder.CamelCaseTest do
+  use ExUnit.Case, async: true
+
+  test "camelCase keys before encoding" do
+    data = %{
+      user: %{
+        first_name: "Han",
+        last_name: "Solo",
+        allies_in_combat: [
+          %{name: "Luke", weapon_of_choice: "lightsaber"},
+          %{name: "Chewie", weapon_of_choice: "bowcaster"},
+          %{name: "Leia", weapon_of_choice: "blaster"},
+        ],
+    },
+}
+
+  expected_data = %{
+    "user" => %{
+      "firstName" => "Han",
+      "lastName" => "Solo",
+      "alliesInCombat" => [
+        %{"name" => "Luke", "weaponOfChoice" => "lightsaber"},
+        %{"name" => "Chewie", "weaponOfChoice" => "bowcaster"},
+        %{"name" => "Leia", "weaponOfChoice" => "blaster"},
+      ],
+  },
+    }
+
+    result = ProperCase.JSONEncoder.CamelCase.encode_to_iodata!(data)
+
+    assert Poison.decode!(result) == expected_data
+  end
+end

--- a/test/json_encoder_test.exs
+++ b/test/json_encoder_test.exs
@@ -2,7 +2,7 @@ defmodule ProperCase.JSONEncoderTest do
   use ExUnit.Case, async: true
 
   defmodule TestEncoder do
-    use ProperCase.JSONEncoder, transform: &ProperCase.to_camel_case/1
+    use ProperCase.JSONEncoder, transform: fn(data) -> %{transformed: data} end
   end
 
   test "transforms before encoding" do
@@ -19,14 +19,16 @@ defmodule ProperCase.JSONEncoderTest do
     }
 
     expected_data = %{
-      "user" => %{
-        "firstName" => "Han",
-        "lastName" => "Solo",
-        "alliesInCombat" => [
-          %{"name" => "Luke", "weaponOfChoice" => "lightsaber"},
-          %{"name" => "Chewie", "weaponOfChoice" => "bowcaster"},
-          %{"name" => "Leia", "weaponOfChoice" => "blaster"},
-        ],
+      "transformed" => %{
+        "user" => %{
+          "first_name" => "Han",
+          "last_name" => "Solo",
+          "allies_in_combat" => [
+            %{"name" => "Luke", "weapon_of_choice" => "lightsaber"},
+            %{"name" => "Chewie", "weapon_of_choice" => "bowcaster"},
+            %{"name" => "Leia", "weapon_of_choice" => "blaster"}
+          ]
+        },
       },
     }
 

--- a/test/json_encoder_test.exs
+++ b/test/json_encoder_test.exs
@@ -1,0 +1,37 @@
+defmodule ProperCase.JSONEncoderTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestEncoder do
+    use ProperCase.JSONEncoder, transform: &ProperCase.to_camel_case/1
+  end
+
+  test "transforms before encoding" do
+    data = %{
+      user: %{
+        first_name: "Han",
+        last_name: "Solo",
+        allies_in_combat: [
+          %{name: "Luke", weapon_of_choice: "lightsaber"},
+          %{name: "Chewie", weapon_of_choice: "bowcaster"},
+          %{name: "Leia", weapon_of_choice: "blaster"},
+        ],
+      },
+    }
+
+    expected_data = %{
+      "user" => %{
+        "firstName" => "Han",
+        "lastName" => "Solo",
+        "alliesInCombat" => [
+          %{"name" => "Luke", "weaponOfChoice" => "lightsaber"},
+          %{"name" => "Chewie", "weaponOfChoice" => "bowcaster"},
+          %{"name" => "Leia", "weaponOfChoice" => "blaster"},
+        ],
+      },
+    }
+
+    result = TestEncoder.encode_to_iodata!(data)
+
+    assert Poison.decode!(result) == expected_data
+  end
+end

--- a/test/plug/snake_case_params_test.exs
+++ b/test/plug/snake_case_params_test.exs
@@ -1,0 +1,39 @@
+defmodule ProperCase.Plug.SnakeCaseParamsTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias ProperCase.Plug.SnakeCaseParams
+
+  test "snake cases incoming params" do
+    params = %{
+      "firstParam" => "first",
+      "SecondParam" => "second",
+      "nestedParam" => %{
+        "innerParam" => "inner",
+      }
+    }
+
+    conn =
+      :get
+      |> conn("/test", params)
+      |> receive_request
+      |> SnakeCaseParams.call([])
+
+    assert conn.params == %{
+      "first_param" => "first",
+      "second_param" => "second",
+      "nested_param" => %{
+        "inner_param" => "inner",
+      }
+    }
+  end
+
+  defp receive_request(conn) do
+    conn
+    |> Plug.Parsers.call(
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    )
+  end
+end

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -1,5 +1,5 @@
 defmodule ProperCaseTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   test ".to_camel_case converts a maps key to `camelCase`" do
     incoming = %{ "user" => %{ "first_name" => "Han", "last_name" => "Solo",


### PR DESCRIPTION
I didn't like the previous plug because it had to `decode |> transform |> encode`. This version creates a module that creates a hook for transforming data before JSON encoding.

This solution is 100% geared towards phoenix.

https://github.com/phoenixframework/phoenix/blob/6be478a24df3df2b97cca1fdad84312f086874b6/lib/phoenix/template.ex#L84-L99