### PR TITLE
Handle non-Enumerable structs as plain values

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -6,12 +6,19 @@ defmodule ProperCase do
   import String, only: [first: 1, replace: 4, downcase: 1, upcase: 1]
 
   @doc """
-  Converts all the keys in a map to `camelCase`
+  Converts all the keys in a map to `camelCase`.
+  If the map is a struct with no `Enumerable` implementation,
+  the struct is considered to be a single value.
   """
   def to_camel_case(map) when is_map(map) do
-    for {key, val} <- map,
-      into: %{},
-      do: {camel_case(key), to_camel_case(val)}
+    try do
+      for {key, val} <- map,
+        into: %{},
+        do: {camel_case(key), to_camel_case(val)}
+    rescue
+      # Not Enumerable
+      Protocol.UndefinedError -> map
+    end
   end
 
   def to_camel_case(list) when is_list(list) do
@@ -75,6 +82,4 @@ defmodule ProperCase do
   def snake_case(val) do
     val |> Macro.underscore
   end
-
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule ProperCase.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.14.3", only: :dev},
+      {:ecto, "~> 2.1", only: [:test]},
       {:plug, "~> 1.2.2", only: [:test]},
       {:poison, ">= 1.3.0", only: [:test]},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,9 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+%{"decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ecto": {:hex, :ecto, "2.1.1", "fa8bdb14be9992b777036e20f183b8c4300cc012a0fae748529ff89b5423f2dd", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "exceptional": {:hex, :exceptional, "2.1.0", "b3bc6c7041a242df9f7e18223649f3d66633827897138cf5f26c46c88b6925ae", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -25,6 +25,14 @@ defmodule ProperCaseTest do
     assert ProperCase.to_camel_case(incoming) === expected
   end
 
+  test ".to_camel_case treats non-Enumerable structs as plain values" do
+    epoch = Ecto.DateTime.from_unix!(0, :microseconds)
+    incoming = %{ "unix_epoch" => epoch }
+    expected = %{ "unixEpoch" => epoch }
+
+    assert ProperCase.to_camel_case(incoming) === expected
+  end
+
   test ".camel_case_key camel cases a string" do
     assert ProperCase.camel_case("chewie_were_home") === "chewieWereHome"
   end


### PR DESCRIPTION
## Reason

Quick fix for #6 

## Implementation Notes

Have tried this change with Ecto in a Phoenix application: works as expected 😄

Not super thrilled about having to use a `try`, but to the best of my knowledge Elixir doesn't provide a way to check if a Protocol implementation exists that doesn't raise. There is `Protocol.assert_impl!`, but that still raises, plus the end result is the same but with a more generic exception type, which is a net loss 😭

I have [a library](https://github.com/expede/exceptional) that can render these functions safe, but the `safe` function is just a nicer interface on top of a `try`.