### PR TITLE
handle non-enumerable structs as plain values in to_snake_case

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -29,12 +29,19 @@ defmodule ProperCase do
   def to_camel_case(final_val), do: final_val
 
   @doc """
-  Converts all the keys in a map to `snake_case`
+  Converts all the keys in a map to `snake_case`.
+  If the map is a struct with no `Enumerable` implementation,
+  the struct is considered to be a single value.
   """
   def to_snake_case(map) when is_map(map) do
-    for {key, val} <- map,
-      into: %{},
-      do: {snake_case(key), to_snake_case(val)}
+    try do
+      for {key, val} <- map,
+        into: %{},
+        do: {snake_case(key), to_snake_case(val)}
+    rescue
+      # Not Enumerable
+      Protocol.UndefinedError -> map
+    end
   end
 
   def to_snake_case(list) when is_list(list) do

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -71,6 +71,14 @@ defmodule ProperCaseTest do
     assert ProperCase.to_snake_case(incoming_params) === expected_params
   end
 
+  test ".to_snake_case treats non-Enumerable structs as plain values" do
+    upload = %Plug.Upload{filename: "README.md", path: "README.md"}
+    incoming = %{"theUpload" => upload}
+    expected = %{"the_upload" => upload}
+
+    assert ProperCase.to_snake_case(incoming) === expected
+  end
+
   test ".snake_case converts a string to `snake_case`" do
     assert ProperCase.snake_case("getToDaChoppa") === "get_to_da_choppa"
   end


### PR DESCRIPTION
Same as https://github.com/johnnyji/proper_case/pull/7, but the other way around.

I added a test that passes a `%Plug.Upload{}` into `ProperCase.to_snake_case/1`, which is the use case that prompted me to create this pull request.