### PR TITLE
Allow integers to be keys!

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -59,6 +59,10 @@ defmodule ProperCase do
     |> Atom.to_string
     |> camel_case
   end
+  
+  def camel_case(val) when is_integer(val) do
+    val
+  end
 
   @doc """
   Converts a string to `camelCase`
@@ -81,6 +85,10 @@ defmodule ProperCase do
     val
     |> Atom.to_string
     |> Macro.underscore
+  end
+  
+  def snake_case(val) when is_integer(val) do
+    val
   end
 
   @doc """


### PR DESCRIPTION
It's not uncommon to have ID maps inside of an object, however if you have one and run it through this the ID will cause this to error out since there's no handling. 

### Example
```elixir
to_camel_case(%{
  other_properies: 4,
  my_snake_map: %{
    1 => %{id: 1, snake_name: "..."}, 
    4 => %{id: 4, snake_name: "..."}}) // ERROR!!!!
```

With this change this error is prevented