### PR TITLE
refactor(Kernel#is_number): Use is_number instead of checking is_inte…

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -59,8 +59,8 @@ defmodule ProperCase do
     |> Atom.to_string
     |> camel_case
   end
-  
-  def camel_case(val) when is_integer(val) or is_float(val) do
+
+  def camel_case(val) when is_number(val) do
     val
   end
 
@@ -86,8 +86,8 @@ defmodule ProperCase do
     |> Atom.to_string
     |> Macro.underscore
   end
-  
-  def snake_case(val) when is_integer(val) or is_float(val) do
+
+  def snake_case(val) when is_number(val) do
     val
   end
 


### PR DESCRIPTION
…ger and is_float

This is a quick refactor that switches out `is_float` and `is_integer` for `is_number`,

Docs for this method can be found here: https://hexdocs.pm/elixir/Kernel.html#is_number/1