### PR TITLE
Update elixir version 1.4.0 -> 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ProperCase.Mixfile do
   def project do
     [app: :proper_case,
      version: "1.2.0",
-     elixir: "~> 1.4.0",
+     elixir: "~> 1.4",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
Fixes `mix deps.compile` warnings:

```
==> proper_case
warning: the dependency :proper_case requires Elixir "~> 1.4.0" but you are running on v1.7.3
```