### PR TITLE
Fix snake case with space in key string

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -98,6 +98,8 @@ defmodule ProperCase do
   Converts a string to `snake_case`
   """
   def snake_case(val) do
-    val |> Macro.underscore
+    val
+    |> String.replace(" ", "")
+    |> Macro.underscore
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ProperCase.Mixfile do
   def project do
     [
       app: :proper_case,
-      version: "1.3.0",
+      version: "1.3.1",
       elixir: "~> 1.4",
       description: description(),
       package: package(),

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -26,7 +26,7 @@ defmodule ProperCaseTest do
   end
 
   test ".to_camel_case treats non-Enumerable structs as plain values" do
-    epoch = DateTime.from_unix!(0, :microseconds)
+    epoch = DateTime.from_unix!(0, :microsecond)
     incoming = %{ "unix_epoch" => epoch }
     expected = %{ "unixEpoch" => epoch }
 
@@ -118,6 +118,10 @@ defmodule ProperCaseTest do
 
   test ".snake_case converts an atom to snake_case string" do
     assert ProperCase.snake_case(:getToDaChoppa) === "get_to_da_choppa"
+  end
+
+  test ".snake_case converts string with spaces to `snake_case`" do
+    assert ProperCase.snake_case("get To Da Choppa") === "get_to_da_choppa"
   end
 
   test ".snake_case converts a number properly" do


### PR DESCRIPTION
Remove spaces on word before convert to snake case to prevent string result like

```elixir
ProperCase.to_snake_case(%{"Multi Word Keys" => "some value"})
%{"multi _word _keys" => "some value"}
```

Fix https://github.com/johnnyji/proper_case/issues/13