### PR TITLE
Eliminate some compilation warnings

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -87,7 +87,7 @@ defmodule ProperCase do
   end
 
   @doc """
-  Converts an to `snake_case` string`
+  Convert a value to a `snake_case` string
   """
   def snake_case(val) when is_atom(val) do
     val
@@ -99,9 +99,6 @@ defmodule ProperCase do
     val
   end
 
-  @doc """
-  Converts a string to `snake_case`
-  """
   def snake_case(val) do
     val
     |> String.replace(" ", "")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ProperCase.Mixfile do
   def project do
     [
       app: :proper_case,
-      version: "1.3.1",
+      version: "1.3.2-dev",
       elixir: "~> 1.4",
       description: description(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule ProperCase.Mixfile do
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      xref: [exclude: [Jason]]
     ]
   end
 


### PR DESCRIPTION
Hello, I updated the code to eliminate some compilation warnings. But because the version of `plug` is too low, upgrading this library will cause the test to fail. I did not rashly support the new version of `plug`, I hope the author has plans to adapt to the new version of plug in the future.