### PR TITLE
Bump installation version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ProperCase is available on hex.pm, and can be installed as:
   1. Add proper_case to your list of dependencies in `mix.exs`:
 ```
         def deps do
-          [{:proper_case, "~> 1.0.2"}]
+          [{:proper_case, "~> 1.3"}]
         end
 ```
   2. For Elixir versions < 1.5: ensure proper_case is started before your application:


### PR DESCRIPTION
This caught me today. The version in the README is much older than the current version and it clashes with the current version of Phoenix.