### PR TITLE
Add links to GitHub in the docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,11 @@ defmodule ProperCase.Mixfile do
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+
+      # Docs.
+      name: "ProperCase",
+      docs: docs()
     ]
   end
 
@@ -46,6 +50,14 @@ defmodule ProperCase.Mixfile do
         "GitHub" => "https://github.com/johnnyji/proper_case",
         "Docs" => "https://github.com/johnnyji/proper_case"
       }
+    ]
+  end
+
+  defp docs do
+    [
+      main: "ProperCase",
+      source_url: "https://github.com/yunmikun2/proper_case",
+      extras: ["README.md"]
     ]
   end
 end


### PR DESCRIPTION
This merge request adds links to the source code in the GitHub repository. This is pretty convenient mechanism that allows to jump right to the definition of a module or a function.

Also, here we add `README.md` to the docs as it contains useful information too.