### PR TITLE
fix(to_camel_case): allow empty string for key

### DIFF
--- a/lib/proper_case.ex
+++ b/lib/proper_case.ex
@@ -69,6 +69,8 @@ defmodule ProperCase do
   @doc """
   Converts a string to `camelCase`
   """
+  def camel_case("", _), do: ""
+
   def camel_case("_" <> rest, mode) do
     "_#{camel_case(rest, mode)}"
   end

--- a/test/proper_case_test.exs
+++ b/test/proper_case_test.exs
@@ -49,6 +49,10 @@ defmodule ProperCaseTest do
     assert ProperCase.camel_case(:no_i_am_your_father) === "noIAmYourFather"
   end
 
+  test ".camel_case_key leaves an empty string key as it is" do
+    assert ProperCase.camel_case("") === ""
+  end
+
   test ".camel_case_key converts a number properly" do
     assert ProperCase.camel_case(12) === 12
     assert ProperCase.camel_case(12.0) === 12.0
@@ -132,6 +136,10 @@ defmodule ProperCaseTest do
 
   test ".snake_case converts string with spaces to `snake_case`" do
     assert ProperCase.snake_case("get To Da Choppa") === "get_to_da_choppa"
+  end
+
+  test ".snake_case leaves an empty string key as it is" do
+    assert ProperCase.snake_case("") === ""
   end
 
   test ".snake_case converts a number properly" do


### PR DESCRIPTION
In this PR I have fixed an error that happens when trying to camel case a map which contains an empty string for key.

![Screenshot_20220216_194015](https://user-images.githubusercontent.com/10255970/154333654-5111b75d-1d50-4da2-8648-4f8e9a03a4dd.png)

